### PR TITLE
[Fix] Revert Java Action Back to Version 3.6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: 'temurin'
           java-version: '17'


### PR DESCRIPTION
## Description

This manually reverts our java action back to version 3.6.0, since the release was deleted. More information [here](https://github.com/actions/setup-java/issues/422).

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Potential solution has been added
- [x] Appropriate labels have been applied
