### PR TITLE
Task08 Creating Enum to calculate the intensity of colors

### DIFF
--- a/basics/src/main/kotlin/de/thermondo/basics/Basics08.kt
+++ b/basics/src/main/kotlin/de/thermondo/basics/Basics08.kt
@@ -1,0 +1,5 @@
+package de.thermondo.basics
+
+/**
+ * Define an enum class named Basics8 with properties and print the rgb value for a specific color.
+ */

--- a/basics/src/main/kotlin/de/thermondo/basics/Basics08.kt
+++ b/basics/src/main/kotlin/de/thermondo/basics/Basics08.kt
@@ -1,5 +1,13 @@
 package de.thermondo.basics
 
-/**
- * Define an enum class named Basics8 with properties and print the rgb value for a specific color.
+/*
+ * This is an extension of the previous example.
+ *
+ * Here let's create another enum class named Basics08 that accepts following parameters
+ * @param r: Int
+ * @param g: Int
+ * @param b: Int
+ * to specify the intensity of the different colors based upon its rgb(RED, GREEN, BLUE)
+ * values using the following formula: (r * 256 + g) * 256 + b
+ * Ex: RED(255, 0, 0) = 16711680
  */

--- a/basics/src/test/kotlin/de/thermondo/basics/Basics08Test.kt
+++ b/basics/src/test/kotlin/de/thermondo/basics/Basics08Test.kt
@@ -1,0 +1,18 @@
+package de.thermondo.basics
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class Basics08Test {
+
+    @Test
+    fun `Validate the rgb value of the color`() {
+        assertEquals(16711680, Basics08.RED.rgb())
+        assertEquals(16779520, Basics08.ORANGE.rgb())
+        assertEquals(16776960, Basics08.YELLOW.rgb())
+        assertEquals(65280, Basics08.GREEN.rgb())
+        assertEquals(255, Basics08.BLUE.rgb())
+        assertEquals(4915330, Basics08.INDIGO.rgb())
+        assertEquals(15631086, Basics08.VIOLET.rgb())
+    }
+}

--- a/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
+++ b/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
@@ -3,16 +3,16 @@ package de.thermondo.solutions.basics
 /**
  * Define an enum class named Basics8Solution with properties and print the rgb value for a specific color.
  */
+@Suppress("MagicNumber")
+enum class Basics08Solution(val r: Int, val g: Int, val b: Int) {
 
-enum class Basics08Solution(val r:Int, val g:Int, val b:Int) {
-    
-    RED(255,0,0),
-    ORANGE(255,265,0),
-    YELLOW(255,255,0),
-    GREEN(0,255,0),
-    BLUE(0,0,255),
-    INDIGO(75,0,130),
-    VIOLET(238,130,238);
+    RED(255, 0, 0),
+    ORANGE(255, 265, 0),
+    YELLOW(255, 255, 0),
+    GREEN(0, 255, 0),
+    BLUE(0, 0, 255),
+    INDIGO(75, 0, 130),
+    VIOLET(238, 130, 238);
 
     val x = 256
     fun rgb() = (r * x + g) * x + b

--- a/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
+++ b/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
@@ -13,7 +13,8 @@ enum class Basics08Solution(val r:Int, val g:Int, val b:Int) {
     INDIGO(75,0,130),
     VIOLET(238,130,238);
 
-    fun rgb() = (r * 256 + g) * 256+ b
+    val x = 256
+    fun rgb() = (r * x + g) * x + b
 }
 
 fun main() {

--- a/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
+++ b/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
@@ -17,13 +17,3 @@ enum class Basics08Solution(val r: Int, val g: Int, val b: Int) {
     val x = 256
     fun rgb() = (r * x + g) * x + b
 }
-
-/*fun main() {
-    println(Basics08Solution.RED.rgb())
-    println(Basics08Solution.ORANGE.rgb())
-    println(Basics08Solution.YELLOW.rgb())
-    println(Basics08Solution.GREEN.rgb())
-    println(Basics08Solution.BLUE.rgb())
-    println(Basics08Solution.INDIGO.rgb())
-    println(Basics08Solution.VIOLET.rgb())
-}*/

--- a/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
+++ b/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
@@ -1,0 +1,27 @@
+package de.thermondo.solutions.basics
+
+/**
+ * Define an enum class named Basics8Solution with properties and print the rgb value for a specific color.
+ */
+
+enum class Basics08Solution(val r:Int, val g:Int, val b:Int) {
+    RED(255,0,0),
+    ORANGE(255,265,0),
+    YELLOW(255,255,0),
+    GREEN(0,255,0),
+    BLUE(0,0,255),
+    INDIGO(75,0,130),
+    VIOLET(238,130,238);
+
+    fun rgb() = (r * 256 + g) * 256+ b
+}
+
+fun main() {
+    println(Basics08Solution.RED.rgb())
+    println(Basics08Solution.ORANGE.rgb())
+    println(Basics08Solution.YELLOW.rgb())
+    println(Basics08Solution.GREEN.rgb())
+    println(Basics08Solution.BLUE.rgb())
+    println(Basics08Solution.INDIGO.rgb())
+    println(Basics08Solution.VIOLET.rgb())
+}

--- a/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
+++ b/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
@@ -1,7 +1,15 @@
 package de.thermondo.solutions.basics
 
-/**
- * Define an enum class named Basics8Solution with properties and print the rgb value for a specific color.
+/*
+ * This is an extension of the previous example.
+ *
+ * Here let's create another enum class named Basics08Solution that accepts following parameters
+ * @param r: Int
+ * @param g: Int
+ * @param b: Int
+ * to specify the intensity of the different colors based upon its rgb(RED, GREEN, BLUE)
+ * values using the following formula: (r * 256 + g) * 256 + b
+ * Ex: RED(255, 0, 0) = 16711680
  */
 @Suppress("MagicNumber")
 enum class Basics08Solution(val r: Int, val g: Int, val b: Int) {

--- a/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
+++ b/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
@@ -18,7 +18,7 @@ enum class Basics08Solution(val r: Int, val g: Int, val b: Int) {
     fun rgb() = (r * x + g) * x + b
 }
 
-fun main() {
+/*fun main() {
     println(Basics08Solution.RED.rgb())
     println(Basics08Solution.ORANGE.rgb())
     println(Basics08Solution.YELLOW.rgb())
@@ -26,4 +26,4 @@ fun main() {
     println(Basics08Solution.BLUE.rgb())
     println(Basics08Solution.INDIGO.rgb())
     println(Basics08Solution.VIOLET.rgb())
-}
+}*/

--- a/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
+++ b/solutions/src/main/kotlin/de/thermondo/solutions/basics/Basics08Solution.kt
@@ -5,6 +5,7 @@ package de.thermondo.solutions.basics
  */
 
 enum class Basics08Solution(val r:Int, val g:Int, val b:Int) {
+    
     RED(255,0,0),
     ORANGE(255,265,0),
     YELLOW(255,255,0),

--- a/solutions/src/test/kotlin/de/thermondo/solutions/basics/Basics08SolutionTest.kt
+++ b/solutions/src/test/kotlin/de/thermondo/solutions/basics/Basics08SolutionTest.kt
@@ -1,0 +1,18 @@
+package de.thermondo.solutions.basics
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class Basics08SolutionTest{
+
+    @Test
+    fun `Validate the rgb value of the color`(){
+        assertEquals(16711680, Basics08Solution.RED.rgb())
+        assertEquals(16779520, Basics08Solution.ORANGE.rgb())
+        assertEquals(16776960, Basics08Solution.YELLOW.rgb())
+        assertEquals(65280, Basics08Solution.GREEN.rgb())
+        assertEquals(255, Basics08Solution.BLUE.rgb())
+        assertEquals(4915330, Basics08Solution.INDIGO.rgb())
+        assertEquals(15631086, Basics08Solution.VIOLET.rgb())
+    }
+}

--- a/solutions/src/test/kotlin/de/thermondo/solutions/basics/Basics08SolutionTest.kt
+++ b/solutions/src/test/kotlin/de/thermondo/solutions/basics/Basics08SolutionTest.kt
@@ -3,10 +3,10 @@ package de.thermondo.solutions.basics
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
-class Basics08SolutionTest{
+class Basics08SolutionTest {
 
     @Test
-    fun `Validate the rgb value of the color`(){
+    fun `Validate the rgb value of the color`() {
         assertEquals(16711680, Basics08Solution.RED.rgb())
         assertEquals(16779520, Basics08Solution.ORANGE.rgb())
         assertEquals(16776960, Basics08Solution.YELLOW.rgb())


### PR DESCRIPTION
## Description

This example is the extension of the task 07 and creates the enum classes to specify the intensity of the colours based on its rgb values.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Tests have been written
- [x] Potential solution has been added
- [x] Appropriate labels have been applied
